### PR TITLE
Amend Account API Token path

### DIFF
--- a/AssetInformationListener/serverless.yml
+++ b/AssetInformationListener/serverless.yml
@@ -22,7 +22,7 @@ functions:
     environment:
       TenureApiUrl: ${ssm:/housing-tl/${self:provider.stage}/tenure-api-url}
       TenureApiToken: ${ssm:/housing-tl/${self:provider.stage}/tenure-api-token}
-      AccountApiUrl: ${ssm:/housing-finance/${self:provider.stage}/account-api-url}
+      AccountApiUrl: ${ssm:/housing-tl/${self:provider.stage}/account-api-url}
       AccountApiToken: ${ssm:/housing-finance/${self:provider.stage}/account-api-token}
     events:
       ### Specify the parameter containing the queue arn used to trigget the lambda function here


### PR DESCRIPTION
Use the T&L Accounts API token to avoid conflicts with MTFH: Finance