### PR TITLE
Upgrade the Asset-Shared version to v0.31.0 and Core.Dynamo version.

### DIFF
--- a/AssetInformationListener.Tests/AssetInformationListener.Tests.csproj
+++ b/AssetInformationListener.Tests/AssetInformationListener.Tests.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Hackney.Core.Http" Version="1.63.0" />
     <PackageReference Include="Hackney.Core.Testing.DynamoDb" Version="1.57.0" />
     <PackageReference Include="Hackney.Core.Testing.Shared" Version="1.54.0" />
-    <PackageReference Include="Hackney.Shared.Asset" Version="0.23.0" />
+    <PackageReference Include="Hackney.Shared.Asset" Version="0.31.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/AssetInformationListener/AssetInformationListener.csproj
+++ b/AssetInformationListener/AssetInformationListener.csproj
@@ -19,11 +19,11 @@
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.0.0" />
     <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.8.3" />
-    <PackageReference Include="Hackney.Core.DynamoDb" Version="1.51.0" />
+    <PackageReference Include="Hackney.Core.DynamoDb" Version="1.79.0" />
     <PackageReference Include="Hackney.Core.Http" Version="1.63.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
-    <PackageReference Include="Hackney.Shared.Asset" Version="0.23.0" />
+    <PackageReference Include="Hackney.Shared.Asset" Version="0.31.0" />
     <PackageReference Include="Hackney.Shared.Tenure" Version="0.16.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
# What:
 - An upgrade to the `Shared.Asset` package version from `v0.27.0` to `v0.31.0`.

# Notes:
 - For this application I also had to update the Hackney.Core.Dynamo package version from `v1.51.0` to version `v1.79.0` because the application had to trouble building, likely, due to the Shared.Asset package using the higher Dynamo version than the application consuming Shared.Asset package.

# Less Important Notes:
 - The package changes are displayed [here](https://github.com/LBHackney-IT/asset-shared/pull/36).
 - Unlike the applications on repairs side, this application interacts with the database directly, as such while the models are identical for all architecture layers right now, it's quite important for this application to be using the correct, updated database layer model to fetch the information.
