### PR TITLE
Updated framework to dotnet 6 because the v3 is no longer supported.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ executors:
       - image: "hashicorp/terraform:1.1.9"
   docker-dotnet:
     docker:
-      - image: mcr.microsoft.com/dotnet/core/sdk:3.1
+      - image: mcr.microsoft.com/dotnet/sdk:6.0
 
 references:
   workspace_root: &workspace_root "~"
@@ -114,7 +114,7 @@ commands:
       - run:
           name: Install Node.js
           command: |
-            curl -sL https://deb.nodesource.com/setup_13.x | bash -
+            curl -sL https://deb.nodesource.com/setup_14.x | bash -
             apt-get update && apt-get install -y nodejs
       - run:
           name: Install serverless CLI

--- a/AssetInformationListener.Tests/AssetInformationListener.Tests.csproj
+++ b/AssetInformationListener.Tests/AssetInformationListener.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
@@ -23,7 +23,7 @@
     <PackageReference Include="Hackney.Core.Testing.DynamoDb" Version="1.57.0" />
     <PackageReference Include="Hackney.Core.Testing.Shared" Version="1.54.0" />
     <PackageReference Include="Hackney.Shared.Asset" Version="0.31.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/AssetInformationListener.Tests/Dockerfile
+++ b/AssetInformationListener.Tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+FROM mcr.microsoft.com/dotnet/sdk:6.0
 
 # disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'

--- a/AssetInformationListener/AssetInformationListener.csproj
+++ b/AssetInformationListener/AssetInformationListener.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
 
@@ -25,13 +25,13 @@
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
     <PackageReference Include="Hackney.Shared.Asset" Version="0.31.0" />
     <PackageReference Include="Hackney.Shared.Tenure" Version="0.16.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
   </ItemGroup>

--- a/AssetInformationListener/Dockerfile
+++ b/AssetInformationListener/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+FROM mcr.microsoft.com/dotnet/sdk:6.0
 
 ARG LBHPACKAGESTOKEN
 ENV LBHPACKAGESTOKEN=$LBHPACKAGESTOKEN

--- a/AssetInformationListener/Properties/launchSettings.json
+++ b/AssetInformationListener/Properties/launchSettings.json
@@ -3,8 +3,8 @@
     "Mock Lambda Test Tool": {
       "commandName": "Executable",
       "commandLineArgs": "--port 5050",
-      "workingDirectory": ".\\bin\\$(Configuration)\\netcoreapp3.1",
-      "executablePath": "%USERPROFILE%\\.dotnet\\tools\\dotnet-lambda-test-tool-3.1.exe",
+      "workingDirectory": ".\\bin\\$(Configuration)\\net6.0",
+      "executablePath": "%USERPROFILE%\\.dotnet\\tools\\dotnet-lambda-test-tool-6.0.exe",
       "environmentVariables": {
         "ENVIRONMENT": "LocalDevelopment",
         "DynamoDb_LocalMode": "true",

--- a/AssetInformationListener/aws-lambda-tools-defaults.json
+++ b/AssetInformationListener/aws-lambda-tools-defaults.json
@@ -8,8 +8,8 @@
   "profile": "default",
   "region": "eu-west-2",
   "configuration": "Release",
-  "framework": "netcoreapp3.1",
-  "function-runtime": "dotnetcore3.1",
+  "framework": "net6.0",
+  "function-runtime": "dotnet6",
   "function-memory-size": 256,
   "function-timeout": 30,
   "function-handler": "AssetInformationListener::AssetInformationListener.SqsFunction::FunctionHandler"

--- a/AssetInformationListener/build.cmd
+++ b/AssetInformationListener/build.cmd
@@ -1,2 +1,2 @@
 dotnet restore
-dotnet lambda package --configuration release --framework netcoreapp3.1 --output-package bin/release/netcoreapp3.1/asset-information-listener.zip
+dotnet lambda package --configuration release --framework net6.0 --output-package bin/release/net6.0/asset-information-listener.zip

--- a/AssetInformationListener/build.sh
+++ b/AssetInformationListener/build.sh
@@ -8,7 +8,7 @@ then
 fi
 
 #dotnet restore
-dotnet tool install --global Amazon.Lambda.Tools --version 4.0.0
+dotnet tool install --global Amazon.Lambda.Tools --version 5.4.5
 
 
 # (for CI) ensure that the newly-installed tools are on PATH
@@ -18,4 +18,4 @@ then
 fi
 
 dotnet restore
-dotnet lambda package --configuration release --framework netcoreapp3.1 --output-package ./bin/release/netcoreapp3.1/asset-information-listener.zip
+dotnet lambda package --configuration release --framework net6.0 --output-package ./bin/release/net6.0/asset-information-listener.zip

--- a/AssetInformationListener/serverless.yml
+++ b/AssetInformationListener/serverless.yml
@@ -1,7 +1,7 @@
 service: asset-information-listener
 provider:
   name: aws
-  runtime: dotnetcore3.1
+  runtime: dotnet6
   memorySize: 2048
   tracing:
     lambda: true
@@ -11,7 +11,7 @@ provider:
   region: eu-west-2
 
 package:
-  artifact: ./bin/release/netcoreapp3.1/asset-information-listener.zip
+  artifact: ./bin/release/net6.0/asset-information-listener.zip
 
 functions:
   AssetInformationListener:


### PR DESCRIPTION
# What:
 - Updated the framework from `dotnet core 3.1` to `dotnet 6`.

# Why:
 - Because 3.1 is no longer supported by the lambda runtime, so we're unable to deploy any new changes.