### PR TITLE
Complete Sonar Cloud configuration setup.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   aws_assume_role: lbh-hackit/aws_assume_role@0.1.0
-  sonarcloud: sonarsource/sonarcloud@1.1.1
+  sonarcloud: sonarsource/sonarcloud@2.0.0
 
 executors:
   docker-python:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,6 @@
 version: 2.1
 
 orbs:
-  aws-ecr: circleci/aws-ecr@3.0.0
-  aws-cli: circleci/aws-cli@0.1.9
   aws_assume_role: lbh-hackit/aws_assume_role@0.1.0
   sonarcloud: sonarsource/sonarcloud@1.1.1
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,9 +253,16 @@ workflows:
       - terraform-compliance-development:
           requires:
             - terraform-init-and-plan-development
-      - terraform-apply-development:
+      - permit-development-release:
+          type: approval
           requires:
             - terraform-compliance-development
+          filters:
+            branches:
+              only: master
+      - terraform-apply-development:
+          requires:
+            - permit-development-release
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,6 +151,12 @@ jobs:
       - run:
           name: Run tests
           command: docker-compose run asset-information-listener-test
+      - run:
+          name: Report
+          command: |
+            mkdir coverage
+            docker cp $(docker ps -aqf "name=asset-information-listener-test"):/app/coverage ./
+            sed -i "s|/app/|$(pwd)/|g" coverage/*/coverage.opencover.xml
   assume-role-development:
     executor: docker-python
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,6 +157,7 @@ jobs:
             mkdir coverage
             docker cp $(docker ps -aqf "name=asset-information-listener-test"):/app/coverage ./
             sed -i "s|/app/|$(pwd)/|g" coverage/*/coverage.opencover.xml
+      - sonarcloud/scan
   assume-role-development:
     executor: docker-python
     steps:

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,0 @@
-sonar-project.properties 

--- a/AssetInformationListener.Tests/AssetInformationListener.Tests.csproj
+++ b/AssetInformationListener.Tests/AssetInformationListener.Tests.csproj
@@ -18,6 +18,10 @@
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Hackney.Core.Http" Version="1.63.0" />
     <PackageReference Include="Hackney.Core.Testing.DynamoDb" Version="1.57.0" />

--- a/AssetInformationListener.Tests/Dockerfile
+++ b/AssetInformationListener.Tests/Dockerfile
@@ -7,17 +7,9 @@ ENV DynamoDb_LocalMode='true'
 ARG LBHPACKAGESTOKEN
 ENV LBHPACKAGESTOKEN=$LBHPACKAGESTOKEN
 
-ARG SONAR_TOKEN
-ENV SONAR_TOKEN=$SONAR_TOKEN
-
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y openjdk-17-jdk
-RUN dotnet tool install --global dotnet-sonarscanner --version 5.6.0
 ENV PATH="$PATH:/root/.dotnet/tools"
-
-RUN dotnet sonarscanner begin /k:"LBHackney-IT_asset-information-listener" /o:"lbhackney-it" /d:sonar.host.url=https://sonarcloud.io /d:sonar.login="${SONAR_TOKEN}"
-
 
 # Copy csproj and restore as distinct layers
 COPY ./AssetInformationListener.sln ./
@@ -35,4 +27,3 @@ RUN dotnet build -c Release -o out AssetInformationListener/AssetInformationList
 RUN dotnet build -c debug -o out AssetInformationListener.Tests/AssetInformationListener.Tests.csproj
 
 CMD dotnet test
-RUN dotnet sonarscanner end /d:sonar.login="${SONAR_TOKEN}"

--- a/AssetInformationListener.Tests/Dockerfile
+++ b/AssetInformationListener.Tests/Dockerfile
@@ -26,4 +26,4 @@ COPY . .
 RUN dotnet build -c Release -o out AssetInformationListener/AssetInformationListener.csproj
 RUN dotnet build -c debug -o out AssetInformationListener.Tests/AssetInformationListener.Tests.csproj
 
-CMD dotnet test
+ENTRYPOINT ["dotnet", "test", "--collect", "XPlat Code Coverage;Format=opencover", "--results-directory", "./coverage"]

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,12 +1,16 @@
+# Project / organisation
 sonar.projectKey=LBHackney-IT_asset-information-listener
 sonar.organization=lbhackney-it
 
-# This is the name and version displayed in the SonarCloud UI.
-#sonar.projectName=asset-information-listener
-#sonar.projectVersion=1.0
+# Service provider
+sonar.host.url=https://sonarcloud.io
 
-# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
-#sonar.sources=.
+# Coverage options, exclude js/ts/css because it expects possibility of C# UI frameworks
+sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml"
+sonar.dotnet.excludeTestProjects=true
+sonar.exclusions="**/*.js, **/*.ts, **/*.css"
+sonar.language=cs
 
-# Encoding of the source code. Default is default system encoding
-#sonar.sourceEncoding=UTF-8 
+# Misc.
+sonar.sourceEncoding=UTF-8 
+sonar.verbose=false


### PR DESCRIPTION
# What:
 - Move the sonar can to be done within the CCI pipeline's container.
 - Use the CCI sonarcloud orb to do the scanning & results upload.
 - Combine static code analysis with tests code coverage.
 - Add manual permit for `development` release.

# Why:
 - The pipeline was occasionally showing a red "X" failure due to Sonar Scan being flaky in regards to when it cares about the missing tests coverage and when not. This PR attempts to make the SonarCloud detect & receive the code coverage.
 - Manual permits to prevent releasing changes too early, given dotnet 8 upgrade is coming.

# Notes:
 - No code coverage is being detected now, because no code has changed. Seems like SonarCloud is more so interested in code coverage on "new code" or "changed code".
 - This PR will sees the Terraform diff for the creation of the `aws_cloudwatch_metric_alarm.dlq_alarm` within the development environment.