### PR TITLE
Run SonarCloud scan in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
   aws-ecr: circleci/aws-ecr@3.0.0
   aws-cli: circleci/aws-cli@0.1.9
   aws_assume_role: lbh-hackit/aws_assume_role@0.1.0
-  sonarcloud: sonarsource/sonarcloud@1.1.1
+  sonarcloud: sonarsource/sonarcloud@2.0.0
 
 executors:
   docker-python:
@@ -153,6 +153,7 @@ jobs:
       - run:
           name: Run tests
           command: docker-compose run asset-information-listener-test
+      - sonarcloud/scan
   assume-role-development:
     executor: docker-python
     steps:


### PR DESCRIPTION
Following the setup steps in https://sonarcloud.io/project/configuration/GitHubCircleCI?id=LBHackney-IT_asset-information-listener2, it looks like we're missing a step.

I also upgraded the scanner to the latest version suggested by the docs.
