### PR TITLE
Add feature branch CCI workflow with Terraform preview steps.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,6 +235,24 @@ jobs:
           stage: "production"
 
 workflows:
+  feature:
+    jobs:
+      - check-code-formatting:
+          context: api-nuget-token-context
+          filters:
+            branches:
+              ignore:
+                - master
+                - release
+      - build-and-test:
+          context:
+            - api-nuget-token-context
+            - SonarCloud
+          filters:
+            branches:
+              ignore:
+                - master
+                - release
   development:
     jobs:
       - check-code-formatting:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,21 @@ commands:
           root: *workspace_root
           paths:
             - .aws
+  terraform-preview:
+    description: "Gives a preview for Terraform configuration changes."
+    parameters:
+      environment:
+        type: string
+    steps:
+      - *attach_workspace
+      - checkout
+      - run:
+          command: |
+            cd ./terraform/<<parameters.environment>>/
+            terraform get -update=true
+            terraform init
+            terraform plan
+          name: terraform preview
   deploy-lambda:
     description: "Deploys via Serverless"
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,10 +239,16 @@ workflows:
     jobs:
       - check-code-formatting:
           context: api-nuget-token-context
+          filters:
+            branches:
+              only: master
       - build-and-test:
           context:
             - api-nuget-token-context
             - SonarCloud
+          filters:
+            branches:
+              only: master
       - assume-role-development:
           context: api-assume-role-housing-development-context
           requires:
@@ -257,22 +263,13 @@ workflows:
           type: approval
           requires:
             - terraform-compliance-development
-          filters:
-            branches:
-              only: master
       - terraform-apply-development:
           requires:
             - permit-development-release
-          filters:
-            branches:
-              only: master
       - deploy-to-development:
           context: api-nuget-token-context
           requires:
             - terraform-apply-development
-          filters:
-            branches:
-              only: master
   staging-and-production:
       jobs:
       - check-code-formatting:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,6 +283,36 @@ workflows:
               ignore:
                 - master
                 - release
+      - assume-role-development:
+          context: api-assume-role-housing-development-context
+          filters:
+            branches:
+              ignore:
+                - master
+                - release
+      - preview-development-terraform:
+          requires:
+            - assume-role-development
+      - assume-role-staging:
+          context: api-assume-role-housing-staging-context
+          filters:
+            branches:
+              ignore:
+                - master
+                - release
+      - preview-staging-terraform:
+          requires:
+            - assume-role-staging
+      - assume-role-production:
+          context: api-assume-role-housing-production-context
+          filters:
+            branches:
+              ignore:
+                - master
+                - release
+      - preview-production-terraform:
+          requires:
+            - assume-role-production
   development:
     jobs:
       - check-code-formatting:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,7 +235,7 @@ jobs:
           stage: "production"
 
 workflows:
-  check-and-deploy-development:
+  development:
     jobs:
       - check-code-formatting:
           context: api-nuget-token-context
@@ -273,7 +273,7 @@ workflows:
           filters:
             branches:
               only: master
-  check-and-deploy-staging-and-production:
+  staging-and-production:
       jobs:
       - check-code-formatting:
           context: api-nuget-token-context

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,6 +233,21 @@ jobs:
     steps:
       - terraform-apply:
           environment: "production"
+  preview-development-terraform:
+    executor: docker-terraform
+    steps:
+      - terraform-preview:
+          environment: "development"
+  preview-staging-terraform:
+    executor: docker-terraform
+    steps:
+      - terraform-preview:
+          environment: "staging"
+  preview-production-terraform:
+    executor: docker-terraform
+    steps:
+      - terraform-preview:
+          environment: "production"
   deploy-to-development:
     executor: docker-dotnet
     steps:


### PR DESCRIPTION
# What:
 - Add feature branch workflow.
 - Add Terraform preview steps to the feature branch workflow.
 - Make CCI workflow names clearer. 

# Why:
 - To be able to see TF changes in advance to prevent accidental resource modification, downgrades, or destruction upon releasing new changes whilst having unforeseen Terraform drift.

# Notes:
 - Renamed workflows to have clearer names - the check and deploy name portion is implied from the environment name.