### PR TITLE
Upgrade the project from dotnet6 to dotnet8.

### DIFF
--- a/AssetInformationListener.Tests/AssetInformationListener.Tests.csproj
+++ b/AssetInformationListener.Tests/AssetInformationListener.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>

--- a/AssetInformationListener.Tests/Dockerfile
+++ b/AssetInformationListener.Tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0
+FROM mcr.microsoft.com/dotnet/sdk:8.0
 
 # disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'

--- a/AssetInformationListener/AssetInformationListener.csproj
+++ b/AssetInformationListener/AssetInformationListener.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
 

--- a/AssetInformationListener/Dockerfile
+++ b/AssetInformationListener/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0
+FROM mcr.microsoft.com/dotnet/sdk:8.0
 
 ARG LBHPACKAGESTOKEN
 ENV LBHPACKAGESTOKEN=$LBHPACKAGESTOKEN

--- a/AssetInformationListener/Properties/launchSettings.json
+++ b/AssetInformationListener/Properties/launchSettings.json
@@ -3,8 +3,8 @@
     "Mock Lambda Test Tool": {
       "commandName": "Executable",
       "commandLineArgs": "--port 5050",
-      "workingDirectory": ".\\bin\\$(Configuration)\\net6.0",
-      "executablePath": "%USERPROFILE%\\.dotnet\\tools\\dotnet-lambda-test-tool-6.0.exe",
+      "workingDirectory": ".\\bin\\$(Configuration)\\net8.0",
+      "executablePath": "%USERPROFILE%\\.dotnet\\tools\\dotnet-lambda-test-tool-8.0.exe",
       "environmentVariables": {
         "ENVIRONMENT": "LocalDevelopment",
         "DynamoDb_LocalMode": "true",

--- a/AssetInformationListener/aws-lambda-tools-defaults.json
+++ b/AssetInformationListener/aws-lambda-tools-defaults.json
@@ -8,8 +8,8 @@
   "profile": "default",
   "region": "eu-west-2",
   "configuration": "Release",
-  "framework": "net6.0",
-  "function-runtime": "dotnet6",
+  "framework": "net8.0",
+  "function-runtime": "dotnet8",
   "function-memory-size": 256,
   "function-timeout": 30,
   "function-handler": "AssetInformationListener::AssetInformationListener.SqsFunction::FunctionHandler"

--- a/AssetInformationListener/build.cmd
+++ b/AssetInformationListener/build.cmd
@@ -1,2 +1,2 @@
 dotnet restore
-dotnet lambda package --configuration release --framework net6.0 --output-package bin/release/net6.0/asset-information-listener.zip
+dotnet lambda package --configuration release --framework net8.0 --output-package bin/release/net8.0/asset-information-listener.zip

--- a/AssetInformationListener/build.sh
+++ b/AssetInformationListener/build.sh
@@ -8,7 +8,7 @@ then
 fi
 
 #dotnet restore
-dotnet tool install --global Amazon.Lambda.Tools --version 5.4.5
+dotnet tool install --global Amazon.Lambda.Tools
 
 
 # (for CI) ensure that the newly-installed tools are on PATH

--- a/AssetInformationListener/build.sh
+++ b/AssetInformationListener/build.sh
@@ -18,4 +18,4 @@ then
 fi
 
 dotnet restore
-dotnet lambda package --configuration release --framework net6.0 --output-package ./bin/release/net6.0/asset-information-listener.zip
+dotnet lambda package --configuration release --framework net8.0 --output-package ./bin/release/net8.0/asset-information-listener.zip

--- a/AssetInformationListener/serverless.yml
+++ b/AssetInformationListener/serverless.yml
@@ -1,7 +1,7 @@
 service: asset-information-listener
 provider:
   name: aws
-  runtime: dotnet6
+  runtime: dotnet8
   memorySize: 2048
   tracing:
     lambda: true

--- a/AssetInformationListener/serverless.yml
+++ b/AssetInformationListener/serverless.yml
@@ -11,7 +11,7 @@ provider:
   region: eu-west-2
 
 package:
-  artifact: ./bin/release/net6.0/asset-information-listener.zip
+  artifact: ./bin/release/net8.0/asset-information-listener.zip
 
 functions:
   AssetInformationListener:


### PR DESCRIPTION
# What:
 - Update all the repository's configuration files to point to `dotnet8` sdk & runtime.
 - Upgrade AWS Lambda Tool package versions & configs to recent versions. 

# Why:
 - Part of the wider `dotnet8` upgrades campaign that's meant to prevent us from getting blocked from deploying code to AWS Lambda (due to `dotnet6` support being dropped) as well as for us to be more responsive during disaster recovery.

# Notes:
 - This PR is for release to the `development` environment.