### PR TITLE
Bump pipeline's dotnet executor's SDK version.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ executors:
       - image: "hashicorp/terraform:1.1.9"
   docker-dotnet:
     docker:
-      - image: mcr.microsoft.com/dotnet/sdk:6.0
+      - image: mcr.microsoft.com/dotnet/sdk:8.0
 
 references:
   workspace_root: &workspace_root "~"


### PR DESCRIPTION
# What:
 - Bump pipeline's dotnet-docker executor's SDK version.

# Why:
 - It was missed in the PR #51. Needed for properly building the application to run on the correct runtime.