### PR TITLE
Fix CCI job for TF deployment to `development` environment.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,7 +198,7 @@ jobs:
   terraform-apply-development:
     executor: docker-terraform
     steps:
-       - terraform-init-then-plan:
+      - terraform-apply:
           environment: "development"
   terraform-init-and-plan-staging:
     executor: docker-terraform


### PR DESCRIPTION
# What:
 - Point TF `development` deployment job to point to the correct CCI TF command.

# Why:
 - Currently, `development` TF infrastructure deployment is impossible due to its job pointing to TF changes preview CCI command.

# Notes:
 - Terraform `development` deployment got broken in PR #31 _(3 years ago)_.