### PR TITLE
`[development]` Correct the VPC subnet ids and attach outgoing traffic security group `[Pt2]`.

### DIFF
--- a/AssetInformationListener/serverless.yml
+++ b/AssetInformationListener/serverless.yml
@@ -129,8 +129,8 @@ custom:
   vpc:
     development:
       subnetIds:
-        - subnet-0deabb5d8fb9c3446
-        - subnet-000b89c249f12a8ad
+        - subnet-0140d06fb84fdb547
+        - subnet-05ce390ba88c42bfd
     staging:
       subnetIds:
         - subnet-06d3de1bd9181b0d7

--- a/AssetInformationListener/serverless.yml
+++ b/AssetInformationListener/serverless.yml
@@ -128,6 +128,8 @@ resources:
 custom:
   vpc:
     development:
+      securityGroupIds:
+        - sg-075dbb441855328ee
       subnetIds:
         - subnet-0140d06fb84fdb547
         - subnet-05ce390ba88c42bfd


### PR DESCRIPTION
# What:
 - Correct the `housing-development` account VPC ids.
 - Added the newly created outgoing traffic security group to the serverless yaml.

# Why:
 - Seems like subnet ids been out of date for a long while.
 - Add missing security group as it's a requirement for attaching lambda to the VPC.
 - This is done to resolve the error mentioned on PR #53 

# Notes:
 - Outgoing traffic allowed because listener needs to reach DynamoDB at a minimum.