### PR TITLE
`[staging/production]` Create an outgoing traffic security group for asset listener `[Pt1]`.

### DIFF
--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -37,6 +37,19 @@ terraform {
   }
 }
 
+data "aws_vpc" "housing_production_vpc" {
+  tags = {
+    Name = "housing-prod"
+  }
+}
+
+module "asset_listener_sg" {
+  source              = "../modules/security_groups/outbound_only_traffic"
+  vpc_id              = data.aws_vpc.housing_production_vpc.id
+  user_resource_name  = "asset_information_listener"
+  environment_name    = var.environment_name
+}
+
 # This is the parameter containing the arn of the topic to which we want to subscribe
 # This will have been created by the service the generates the events in which we are interested
 

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -37,6 +37,19 @@ terraform {
   }
 }
 
+data "aws_vpc" "housing_staging_vpc" {
+  tags = {
+    Name = "housing-stg"
+  }
+}
+
+module "asset_listener_sg" {
+  source              = "../modules/security_groups/outbound_only_traffic"
+  vpc_id              = data.aws_vpc.housing_staging_vpc.id
+  user_resource_name  = "asset_information_listener"
+  environment_name    = var.environment_name
+}
+
 # This is the parameter containing the arn of the topic to which we want to subscribe
 # This will have been created by the service the generates the events in which we are interested
 


### PR DESCRIPTION
# What:
 - Add staging outgoing traffic security group.
 - Add production outgoing traffic security group.

# Why:
 - To have a security group to attach to resolve pipeline deployment error when it tries to attach lambda as specified to the VPC.

# Notes:
 - Continuation of PR #53. 