### PR TITLE
`[staging/production]` Correct the VPC subnet ids and attach outgoing traffic security group `[Pt2]`.

### DIFF
--- a/AssetInformationListener/serverless.yml
+++ b/AssetInformationListener/serverless.yml
@@ -143,5 +143,5 @@ custom:
       securityGroupIds:
         - sg-0194d834476155006
       subnetIds:
-        - subnet-01d3657f97a243261
-        - subnet-0b7b8fea07efabf34
+        - subnet-0beb266003a56ca82
+        - subnet-06a697d86a9b6ed01

--- a/AssetInformationListener/serverless.yml
+++ b/AssetInformationListener/serverless.yml
@@ -134,6 +134,8 @@ custom:
         - subnet-0140d06fb84fdb547
         - subnet-05ce390ba88c42bfd
     staging:
+      securityGroupIds:
+        - sg-0104c0c55226675ed
       subnetIds:
         - subnet-06d3de1bd9181b0d7
         - subnet-0ed7d7713d1127656

--- a/AssetInformationListener/serverless.yml
+++ b/AssetInformationListener/serverless.yml
@@ -137,8 +137,8 @@ custom:
       securityGroupIds:
         - sg-0104c0c55226675ed
       subnetIds:
-        - subnet-06d3de1bd9181b0d7
-        - subnet-0ed7d7713d1127656
+        - subnet-0ea0020a44b98a2ca
+        - subnet-0743d86e9b362fa38
     production:
       securityGroupIds:
         - sg-0194d834476155006

--- a/AssetInformationListener/serverless.yml
+++ b/AssetInformationListener/serverless.yml
@@ -140,6 +140,8 @@ custom:
         - subnet-06d3de1bd9181b0d7
         - subnet-0ed7d7713d1127656
     production:
+      securityGroupIds:
+        - sg-0194d834476155006
       subnetIds:
         - subnet-01d3657f97a243261
         - subnet-0b7b8fea07efabf34


### PR DESCRIPTION
# What:
 - Attach lambda to the VPC.
 - Add missing security groups.
 - Correct VPC subnet ids.

# Why:
 - To resolve the pipeline deployment error on invalid configuration.

# Notes:
 - Continuation of PR #56 .
 - Development was already done on PR #55 .