### PR TITLE
TS-2000 Update shared asset package to 0.44.0

### DIFF
--- a/AssetInformationListener.Tests/AssetInformationListener.Tests.csproj
+++ b/AssetInformationListener.Tests/AssetInformationListener.Tests.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Hackney.Core.Http" Version="1.63.0" />
     <PackageReference Include="Hackney.Core.Testing.DynamoDb" Version="1.57.0" />
     <PackageReference Include="Hackney.Core.Testing.Shared" Version="1.54.0" />
-    <PackageReference Include="Hackney.Shared.Asset" Version="0.31.0" />
+    <PackageReference Include="Hackney.Shared.Asset" Version="0.44.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/AssetInformationListener/AssetInformationListener.csproj
+++ b/AssetInformationListener/AssetInformationListener.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Hackney.Core.Http" Version="1.63.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
-    <PackageReference Include="Hackney.Shared.Asset" Version="0.31.0" />
+    <PackageReference Include="Hackney.Shared.Asset" Version="0.44.0" />
     <PackageReference Include="Hackney.Shared.Tenure" Version="0.16.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## WHAT
When new tenure is created and the listener updates the asset based on the tenure details the following TA specific properties are lost:

1. isTemporaryAccommodationBlock
2. isPartOfTemporaryAccommodationBlock
3. temporaryAccommodationParentAssetId

This results in data loss and records being in invalid state. This happens when creating new bookings in TA.

## WHY
The listener is using old `Hackney.Shared.Asset` package which is lacking the above properties from `Hackney.Shared.Asset.Domain` object. When the listener loads the target asset from the database and then converts it to domain object before saving it back with the tenure details the missing properties results in data loss.

## HOW
Update the Hackney.Shared.Asset package to version `0.44.0`

This has been tested against local backend setup.